### PR TITLE
Add cross-browser restore and clipboard workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 1.50 - 2025-10-07
+- Added Firefox support by introducing a shared WebExtensions browser adapter.
+- Updated the background service worker to preserve copy workflow and store the last session.
+- Added session restore and clipboard import actions with URL validation.
+- Refreshed the popup UI with new controls and status messaging.
+- Updated documentation and permissions, keeping the extension offline-only.

--- a/README.md
+++ b/README.md
@@ -1,50 +1,56 @@
-# Copy Tab URLs Chrome Extension
+# Copy Tab URLs Browser Extension
 
 ## Overview
 
-The Copy Tab URLs Chrome Extension is a simple and efficient tool that allows users to quickly copy the URLs of all open tabs in their Chrome browser. This extension streamlines the process of sharing or saving multiple webpage addresses at once.
+Copy Tab URLs is a lightweight, offline-ready WebExtensions add-on that helps you collect, copy, and reopen the URLs from your current browsing session. The extension now supports Chromium-based browsers (Chrome, Brave, Edge) and Firefox with the same MV3 codebase.
 
 ## Features
 
-- One-click functionality to copy open tab URLs
-- Option to copy URLs from all windows or just the current window
-- Automatically formats URLs, separating each with a new line
-- Provides user feedback and statistics through the popup interface
-- Lightweight and easy to use
+- Copy the URLs from the current window or every open browser window.
+- Automatically filters out internal pages such as `chrome://` and `about:`.
+- Displays real-time status updates and copy statistics in the popup.
+- Saves the most recent copy session so you can restore those tabs later.
+- Opens URL lists from your clipboard (newline-separated or JSON array/object).
+- Remembers your preferences with `storage.sync` and keeps the last session in `storage.local`.
+- Requires no network access and works completely offline.
 
 ## Installation
 
-1. Download or clone this repository to your local machine.
-2. Open Google Chrome and navigate to `chrome://extensions/`.
-3. Enable "Developer mode" in the top right corner.
-4. Click "Load unpacked" and select the directory containing the extension files.
+### Chrome / Brave (Chromium)
+1. Clone or download this repository to your machine.
+2. Open `chrome://extensions/` (or `brave://extensions/`).
+3. Enable **Developer mode** in the top-right corner.
+4. Click **Load unpacked** and select the project directory.
+
+### Firefox
+1. Clone or download this repository to your machine.
+2. Open Firefox and navigate to `about:debugging#/runtime/this-firefox`.
+3. Click **Load Temporary Add-on…** and choose the `manifest.json` file in the project directory.
+4. To install a signed package, run your preferred build/signing process and load the resulting `.xpi` through the same page.
 
 ## Usage
 
-1. Click on the extension icon in your Chrome toolbar.
-2. Select whether you want to copy URLs from all windows or just the current window.
-3. Click the "Copy URLs" button.
-4. The URLs of the selected tabs will be copied to your clipboard.
-5. An alert will confirm that the URLs have been copied successfully, along with the number of URLs copied.
+1. Open the popup from the toolbar.
+2. Decide whether to copy from all browser windows and whether restored URLs should open in a new window.
+3. Click **Copy URLs to Clipboard** to capture the list. The popup shows progress and writes the final list to your clipboard.
+4. Use **Restore Last Saved** to reopen the most recently copied URLs, or **Open URLs from Clipboard** to parse a list you already have.
+5. Review the stats panel for counts, character totals, and last saved timestamps.
 
-## File Structure
+### Clipboard Format Support
+- Plain text with one URL per line.
+- JSON arrays (e.g. `["https://example.com", "https://openai.com"]`).
+- JSON objects with a `urls` property (e.g. `{ "urls": ["https://example.com"] }`).
 
-- `manifest.json`: Contains extension metadata and permissions
-- `background.js`: Handles the core functionality of copying URLs
-- `popup.html`: Provides the user interface for selecting copy options
-- `popup.js`: Manages the popup functionality and user interactions
-- `icons/`: Directory containing extension icons
+## QA Checklist
 
-## Permissions
+Perform these manual checks on Linux and Windows using Brave, Chrome, and Firefox:
 
-This extension requires the following permissions:
-
-- `tabs`: To access and read the URLs of open tabs
-- `clipboardWrite`: To copy the URLs to the clipboard
-
-## Contributing
-
-Contributions to improve the extension are welcome. Please feel free to submit pull requests or open issues for any bugs or feature requests.
+- Copy URLs from the current window and all windows.
+- Confirm the clipboard text is updated after copying.
+- Restore the last saved session in both the current window and a new window.
+- Open URLs from the clipboard using newline-separated text.
+- Open URLs from the clipboard using a JSON array or `{ urls: [] }` object.
+- Verify internal URLs such as `chrome://` and `about:` are excluded.
 
 ## License
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,22 @@
+# TASKS
+
+## Phase 1 – Cross-browser foundation
+- [ ] Add the WebExtensions browser adapter and ensure it loads in the service worker and popup (adapter active in both contexts). [#P1-T1]
+- [ ] Update Manifest V3 metadata, permissions, and Firefox-specific settings (manifest validates in Chrome & Firefox). [#P1-T2]
+
+## Phase 2 – Background capabilities
+- [ ] Refactor the background service worker to use the shared adapter and maintain existing copy/status flow (copy action mirrors current UX). [#P2-T1]
+- [ ] Persist the last copied session in `storage.local` and implement restore helpers for current/new windows (restore reopens saved URLs). [#P2-T2]
+- [ ] Implement clipboard import handling with newline and JSON parsing plus internal URL filtering (invalid lines ignored gracefully). [#P2-T3]
+
+## Phase 3 – Popup experience
+- [ ] Redesign the popup UI with new buttons, open-in-new-window toggle, and status messaging (UI matches spec and remains accessible). [#P3-T1]
+- [ ] Wire popup logic to new background actions, including settings persistence and clipboard interactions (all buttons trigger expected behavior). [#P3-T2]
+
+## Phase 4 – Quality & resilience
+- [ ] Add comprehensive error handling for empty results, clipboard failures, and blocked schemes (errors reported without crashes). [#P4-T1]
+- [ ] Verify async flows resolve cleanly with no unhandled promise rejections (console remains clear during manual testing). [#P4-T2]
+
+## Phase 5 – Documentation & release
+- [ ] Update README with multi-browser setup, feature overview, and QA checklist (docs reflect new workflow). [#P5-T1]
+- [ ] Record the 1.50 release in CHANGELOG and confirm version bump (changelog and manifest show 1.50). [#P5-T2]

--- a/background.js
+++ b/background.js
@@ -1,67 +1,305 @@
-chrome.action.onClicked.addListener(copyUrls);
+importScripts('vendor/browser-adapter.js');
 
-chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-  if (request.action === "copyUrls") {
-    copyUrls(request.copyAllTabs);
+const runtime = (typeof browser !== 'undefined' ? browser.runtime : chrome.runtime);
+const storage = (typeof browser !== 'undefined' ? browser.storage : chrome.storage);
+const tabsApi = (typeof browser !== 'undefined' ? browser.tabs : chrome.tabs);
+const windowsApi = (typeof browser !== 'undefined' ? browser.windows : chrome.windows);
+
+const INTERNAL_PROTOCOLS = new Set(['chrome:', 'chrome-extension:', 'moz-extension:', 'about:', 'edge:', 'view-source:']);
+
+runtime.onMessage.addListener((message, sender, sendResponse) => {
+  const action = message && message.action;
+
+  let handlerPromise;
+  switch (action) {
+    case 'copyUrls':
+      handlerPromise = handleCopyUrls(Boolean(message.copyAllTabs));
+      break;
+    case 'restoreLastSaved':
+      handlerPromise = handleRestoreLastSaved(Boolean(message.openInNewWindow));
+      break;
+    case 'openFromClipboard':
+      handlerPromise = handleRestoreFromClipboard(Boolean(message.openInNewWindow), message.clipboardText);
+      break;
+    default:
+      handlerPromise = Promise.resolve({ ok: false, error: 'Unknown action' });
+      break;
   }
+
+  handlerPromise
+    .then(result => sendResponse(result))
+    .catch(error => {
+      console.error('Unhandled background error:', error);
+      sendResponse({ ok: false, error: error && error.message ? error.message : 'Unexpected error' });
+    });
+
+  return true;
 });
 
-async function copyUrls(copyAllTabs = true) {
+async function handleCopyUrls(copyAllTabs) {
   try {
-    chrome.runtime.sendMessage({ action: "updateStatus", message: "Querying tabs..." });
-    
-    let tabs;
-    if (copyAllTabs) {
-      tabs = await chrome.tabs.query({});
-    } else {
-      const [currentTab] = await chrome.tabs.query({ active: true, currentWindow: true });
-      tabs = await chrome.tabs.query({ windowId: currentTab.windowId });
+    await safeSendMessage({ action: 'updateStatus', message: 'Querying tabs…' });
+
+    const tabs = await getTabs(copyAllTabs);
+    const urls = tabs.map(tab => tab.url).filter(url => isUrlAllowed(url));
+
+    if (urls.length === 0) {
+      throw new ExtensionError('No copyable URLs found.');
     }
-    
-    const urls = tabs.map(tab => tab.url);
-    
-    chrome.runtime.sendMessage({ 
-      action: "updateStatus", 
-      message: `Copying ${urls.length} URLs...` 
+
+    const text = urls.join('\n');
+
+    await safeSendMessage({
+      action: 'updateStatus',
+      message: `Preparing ${urls.length} URL${urls.length === 1 ? '' : 's'}…`
     });
-    
-    const nonChromeUrls = urls.filter(url => !url.startsWith('chrome://'));
-    
-    if (nonChromeUrls.length === 0) {
-      throw new Error('No non-chrome:// URLs found to copy');
-    }
-    
-    const text = nonChromeUrls.join('\n');
-    
-    chrome.runtime.sendMessage({ 
-      action: "copyComplete", 
-      text: text,
+
+    await storage.local.set({
+      lastSession: {
+        savedAt: new Date().toISOString(),
+        urls
+      }
+    });
+
+    await safeSendMessage({
+      action: 'copyComplete',
+      text,
       stats: {
         tabCount: tabs.length,
-        urlCount: nonChromeUrls.length,
+        urlCount: urls.length,
         characterCount: text.length
       }
     });
-  } catch (err) {
-    console.error('Error:', err);
-    chrome.runtime.sendMessage({ 
-      action: "copyError", 
-      message: `Failed to copy URLs: ${err.message}` 
-    });
+
+    return { ok: true, count: urls.length };
+  } catch (error) {
+    await reportCopyError(error);
+    return { ok: false, error: error.message };
   }
 }
 
-function copyToClipboard(text) {
-  const textArea = document.createElement("textarea");
-  textArea.value = text;
-  document.body.appendChild(textArea);
-  textArea.select();
-  let success = false;
+async function handleRestoreLastSaved(openInNewWindow) {
   try {
-    success = document.execCommand('copy');
-  } catch (err) {
-    console.error("Failed to copy: ", err);
+    await safeSendMessage({ action: 'updateStatus', message: 'Loading last session…' });
+
+    const { lastSession } = await storage.local.get('lastSession');
+    if (!lastSession || !Array.isArray(lastSession.urls) || lastSession.urls.length === 0) {
+      throw new ExtensionError('No saved session available.');
+    }
+
+    const parsedUrls = parseUrls(lastSession.urls);
+    if (parsedUrls.length === 0) {
+      throw new ExtensionError('Saved session is empty or invalid.');
+    }
+
+    const openedCount = await restoreUrls(parsedUrls, openInNewWindow);
+
+    await safeSendMessage({
+      action: 'operationComplete',
+      message: `Opened ${openedCount} URL${openedCount === 1 ? '' : 's'} from last session.`,
+      stats: {
+        openedCount,
+        source: 'lastSession',
+        savedAt: lastSession.savedAt || null
+      }
+    });
+
+    return { ok: true, count: openedCount };
+  } catch (error) {
+    await reportOperationError(error);
+    return { ok: false, error: error.message };
   }
-  document.body.removeChild(textArea);
-  return success;
 }
+
+async function handleRestoreFromClipboard(openInNewWindow, clipboardText) {
+  try {
+    if (typeof clipboardText !== 'string' || clipboardText.trim().length === 0) {
+      throw new ExtensionError('Clipboard does not contain any text.');
+    }
+
+    await safeSendMessage({ action: 'updateStatus', message: 'Parsing clipboard content…' });
+
+    const parsedUrls = parseUrls(clipboardText);
+    if (parsedUrls.length === 0) {
+      throw new ExtensionError('No valid URLs found in the clipboard.');
+    }
+
+    const openedCount = await restoreUrls(parsedUrls, openInNewWindow);
+
+    await safeSendMessage({
+      action: 'operationComplete',
+      message: `Opened ${openedCount} URL${openedCount === 1 ? '' : 's'} from clipboard.`,
+      stats: {
+        openedCount,
+        source: 'clipboard'
+      }
+    });
+
+    return { ok: true, count: openedCount };
+  } catch (error) {
+    await reportOperationError(error);
+    return { ok: false, error: error.message };
+  }
+}
+
+async function getTabs(copyAllTabs) {
+  if (copyAllTabs) {
+    return await tabsApi.query({});
+  }
+
+  const [activeTab] = await tabsApi.query({ active: true, currentWindow: true });
+  if (!activeTab) {
+    return await tabsApi.query({ currentWindow: true });
+  }
+  return await tabsApi.query({ windowId: activeTab.windowId });
+}
+
+async function restoreUrls(urls, openInNewWindow) {
+  const uniqueUrls = urls.filter((url, index) => urls.indexOf(url) === index);
+
+  if (openInNewWindow || !(await getCurrentWindowId())) {
+    await windowsApi.create({ url: uniqueUrls });
+    return uniqueUrls.length;
+  }
+
+  const [activeTab] = await tabsApi.query({ active: true, currentWindow: true });
+  const targetWindowId = activeTab ? activeTab.windowId : null;
+
+  if (!targetWindowId) {
+    await windowsApi.create({ url: uniqueUrls });
+    return uniqueUrls.length;
+  }
+
+  await tabsApi.update(activeTab.id, { url: uniqueUrls[0], active: true });
+
+  for (let index = 1; index < uniqueUrls.length; index += 1) {
+    await tabsApi.create({ url: uniqueUrls[index], windowId: targetWindowId, active: false });
+  }
+
+  return uniqueUrls.length;
+}
+
+async function getCurrentWindowId() {
+  try {
+    const currentWindow = windowsApi.getCurrent ? await windowsApi.getCurrent({ populate: false }) : null;
+    return currentWindow ? currentWindow.id : null;
+  } catch (error) {
+    return null;
+  }
+}
+
+function parseUrls(input) {
+  let rawList = [];
+
+  if (!input) {
+    return [];
+  }
+
+  if (Array.isArray(input)) {
+    rawList = input;
+  } else if (typeof input === 'string') {
+    const trimmed = input.trim();
+    if (!trimmed) {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        rawList = parsed;
+      } else if (parsed && Array.isArray(parsed.urls)) {
+        rawList = parsed.urls;
+      } else if (parsed && typeof parsed.urls === 'string') {
+        rawList = [parsed.urls];
+      } else {
+        rawList = splitLines(trimmed);
+      }
+    } catch (_) {
+      rawList = splitLines(trimmed);
+    }
+  } else if (typeof input === 'object' && input.urls) {
+    rawList = Array.isArray(input.urls) ? input.urls : [input.urls];
+  }
+
+  const validated = [];
+
+  for (const candidate of rawList) {
+    if (typeof candidate !== 'string') {
+      continue;
+    }
+    const url = validateUrl(candidate.trim());
+    if (url) {
+      validated.push(url);
+    }
+  }
+
+  return validated;
+}
+
+function splitLines(text) {
+  return text.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+}
+
+function validateUrl(value) {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const url = new URL(value);
+    if (!isUrlAllowed(url.href)) {
+      return null;
+    }
+    return url.href;
+  } catch (error) {
+    return null;
+  }
+}
+
+function isUrlAllowed(url) {
+  if (!url || typeof url !== 'string') {
+    return false;
+  }
+
+  const lower = url.toLowerCase();
+  for (const protocol of INTERNAL_PROTOCOLS) {
+    if (lower.startsWith(protocol)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+async function safeSendMessage(payload) {
+  try {
+    await runtime.sendMessage(payload);
+  } catch (error) {
+    if (error && error.message && error.message.includes('Receiving end does not exist')) {
+      return;
+    }
+    console.warn('Failed to deliver message to popup:', error);
+  }
+}
+
+async function reportCopyError(error) {
+  console.error('Failed to copy URLs:', error);
+  await safeSendMessage({
+    action: 'copyError',
+    message: `Failed to copy URLs: ${error && error.message ? error.message : 'Unknown error'}`
+  });
+}
+
+async function reportOperationError(error) {
+  console.error('Operation failed:', error);
+  await safeSendMessage({
+    action: 'operationError',
+    message: error && error.message ? error.message : 'Operation failed.'
+  });
+}
+
+function ExtensionError(message) {
+  this.name = 'ExtensionError';
+  this.message = message;
+}
+ExtensionError.prototype = Object.create(Error.prototype);
+ExtensionError.prototype.constructor = ExtensionError;

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,12 @@
 {
   "manifest_version": 3,
   "name": "Copy Tab URLs",
-  "version": "1.48",
+  "version": "1.50",
+  "description": "Copy, restore, and reopen tab URLs across Chrome, Brave, and Firefox.",
   "permissions": [
     "tabs",
-    "scripting",
-    "storage"
+    "storage",
+    "clipboardWrite"
   ],
   "host_permissions": [
     "<all_urls>"
@@ -20,6 +21,16 @@
   },
   "background": {
     "service_worker": "background.js"
+  },
+  "icons": {
+    "16": "icons/icon16.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "copy-tab-urls@example.com",
+      "strict_min_version": "109.0"
+    }
   }
 }
-

--- a/popup.html
+++ b/popup.html
@@ -1,23 +1,91 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
+  <meta charset="UTF-8">
   <title>Copy Tab URLs</title>
   <style>
-    body { font-family: Arial, sans-serif; width: 300px; padding: 10px; }
-    button { margin-top: 10px; }
-    #message { margin-top: 10px; font-weight: bold; }
-    #stats { margin-top: 10px; font-size: 0.9em; }
+    :root {
+      color-scheme: light dark;
+    }
+    body {
+      font-family: Arial, sans-serif;
+      width: 320px;
+      padding: 12px;
+      margin: 0;
+      background-color: var(--popup-background, #ffffff);
+      color: var(--popup-text, #1a1a1a);
+    }
+    h1 {
+      margin: 0 0 12px;
+      font-size: 18px;
+    }
+    .controls {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      margin-bottom: 12px;
+    }
+    .checkbox {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+    }
+    button {
+      width: 100%;
+      padding: 8px 12px;
+      margin-top: 6px;
+      font-size: 14px;
+      cursor: pointer;
+      border: 1px solid #888;
+      border-radius: 4px;
+      background-color: #f3f3f3;
+    }
+    button.primary {
+      background-color: #1976d2;
+      border-color: #1976d2;
+      color: #ffffff;
+    }
+    button:disabled {
+      opacity: 0.6;
+      cursor: default;
+    }
+    #message {
+      margin-top: 12px;
+      font-weight: bold;
+      min-height: 20px;
+    }
+    #message.error {
+      color: #c62828;
+    }
+    #stats {
+      margin-top: 8px;
+      font-size: 12px;
+      line-height: 1.4;
+    }
+    #stats p {
+      margin: 2px 0;
+    }
   </style>
 </head>
 <body>
   <h1>Copy Tab URLs</h1>
-  <label>
-    <input type="checkbox" id="allTabsToggle"> Copy from all windows
-  </label>
-  <button id="copyButton">Copy URLs to Clipboard</button>
-  <div id="message"></div>
-  <div id="stats"></div>
+  <div class="controls">
+    <label class="checkbox">
+      <input type="checkbox" id="allTabsToggle">
+      <span>Copy from all windows</span>
+    </label>
+    <label class="checkbox">
+      <input type="checkbox" id="openInNewWindowToggle" checked>
+      <span>Open in new window</span>
+    </label>
+  </div>
+  <button id="copyButton" class="primary">Copy URLs to Clipboard</button>
+  <button id="restoreButton">Restore Last Saved (new window)</button>
+  <button id="clipboardButton">Open URLs from Clipboard (this window)</button>
+  <div id="message" role="status" aria-live="polite"></div>
+  <div id="stats" aria-live="polite"></div>
+  <script src="vendor/browser-adapter.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>
-

--- a/popup.js
+++ b/popup.js
@@ -1,59 +1,266 @@
-document.addEventListener('DOMContentLoaded', () => {
-  const copyButton = document.getElementById('copyButton');
-  const messageDiv = document.getElementById('message');
-  const statsDiv = document.getElementById('stats');
-  const allTabsToggle = document.getElementById('allTabsToggle');
+const browserApi = typeof browser !== 'undefined' ? browser : chrome;
 
-  // Load saved state
-  chrome.storage.sync.get('copyAllTabs', (data) => {
-    allTabsToggle.checked = data.copyAllTabs !== false;
-  });
+const COPY_BUTTON_DEFAULT = 'Copy URLs to Clipboard';
+const COPY_BUTTON_WORKING = 'Copying…';
+const RESTORE_PREP_MESSAGE = 'Preparing to restore…';
+const CLIPBOARD_PREP_MESSAGE = 'Reading clipboard…';
 
-  allTabsToggle.addEventListener('change', (e) => {
-    chrome.storage.sync.set({ copyAllTabs: e.target.checked });
-  });
+const state = {
+  copyAllTabs: true,
+  openInNewWindow: true,
+  busyAction: null
+};
 
-  copyButton.addEventListener('click', () => {
-    chrome.storage.sync.get('copyAllTabs', (data) => {
-      chrome.runtime.sendMessage({ 
-        action: "copyUrls", 
-        copyAllTabs: data.copyAllTabs !== false 
-      });
-    });
-    copyButton.disabled = true;
-    copyButton.textContent = 'Copying...';
-    messageDiv.textContent = 'Initializing...';
-    statsDiv.textContent = '';
-  });
+const elements = {};
 
-  chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-    switch(request.action) {
-      case "updateStatus":
-        messageDiv.textContent = request.message;
-        break;
-      case "copyComplete":
-        navigator.clipboard.writeText(request.text).then(() => {
-          messageDiv.textContent = `${request.stats.urlCount} URLs copied to clipboard!`;
-          statsDiv.innerHTML = `
-            <p>Tabs processed: ${request.stats.tabCount}</p>
-            <p>URLs copied: ${request.stats.urlCount}</p>
-            <p>Total characters: ${request.stats.characterCount}</p>
-          `;
-          copyButton.disabled = false;
-          copyButton.textContent = 'Copy URLs to Clipboard';
-        }).catch(err => {
-          messageDiv.textContent = `Failed to copy URLs: ${err.message}`;
-          statsDiv.textContent = '';
-          copyButton.disabled = false;
-          copyButton.textContent = 'Try Again';
-        });
-        break;
-      case "copyError":
-        messageDiv.textContent = request.message;
-        statsDiv.textContent = '';
-        copyButton.disabled = false;
-        copyButton.textContent = 'Try Again';
-        break;
+document.addEventListener('DOMContentLoaded', async () => {
+  cacheElements();
+  attachListeners();
+  await loadSettings();
+  updateButtonLabels();
+});
+
+function cacheElements() {
+  elements.copyButton = document.getElementById('copyButton');
+  elements.restoreButton = document.getElementById('restoreButton');
+  elements.clipboardButton = document.getElementById('clipboardButton');
+  elements.allTabsToggle = document.getElementById('allTabsToggle');
+  elements.openInNewWindowToggle = document.getElementById('openInNewWindowToggle');
+  elements.message = document.getElementById('message');
+  elements.stats = document.getElementById('stats');
+}
+
+function attachListeners() {
+  browserApi.runtime.onMessage.addListener(handleRuntimeMessage);
+
+  elements.allTabsToggle.addEventListener('change', async (event) => {
+    state.copyAllTabs = event.target.checked;
+    try {
+      await browserApi.storage.sync.set({ copyAllTabs: state.copyAllTabs });
+    } catch (error) {
+      console.error('Failed to persist copyAllTabs setting', error);
     }
   });
-});
+
+  elements.openInNewWindowToggle.addEventListener('change', async (event) => {
+    state.openInNewWindow = event.target.checked;
+    updateButtonLabels();
+    try {
+      await browserApi.storage.sync.set({ openInNewWindow: state.openInNewWindow });
+    } catch (error) {
+      console.error('Failed to persist openInNewWindow setting', error);
+    }
+  });
+
+  elements.copyButton.addEventListener('click', async () => {
+    if (state.busyAction) {
+      return;
+    }
+
+    setBusyState('copy');
+    setMessage('Initializing…');
+    clearStats();
+
+    try {
+      await browserApi.runtime.sendMessage({
+        action: 'copyUrls',
+        copyAllTabs: state.copyAllTabs
+      });
+    } catch (error) {
+      handleImmediateError(`Failed to start copy: ${error.message}`);
+    }
+  });
+
+  elements.restoreButton.addEventListener('click', async () => {
+    if (state.busyAction) {
+      return;
+    }
+
+    setBusyState('restore');
+    setMessage(RESTORE_PREP_MESSAGE);
+    clearStats();
+
+    try {
+      await browserApi.runtime.sendMessage({
+        action: 'restoreLastSaved',
+        openInNewWindow: state.openInNewWindow
+      });
+    } catch (error) {
+      handleImmediateError(`Failed to start restore: ${error.message}`);
+    }
+  });
+
+  elements.clipboardButton.addEventListener('click', async () => {
+    if (state.busyAction) {
+      return;
+    }
+
+    setBusyState('clipboard');
+    setMessage(CLIPBOARD_PREP_MESSAGE);
+    clearStats();
+
+    try {
+      const clipboardText = await navigator.clipboard.readText();
+      if (!clipboardText.trim()) {
+        throw new Error('Clipboard is empty.');
+      }
+      await browserApi.runtime.sendMessage({
+        action: 'openFromClipboard',
+        openInNewWindow: state.openInNewWindow,
+        clipboardText
+      });
+    } catch (error) {
+      handleImmediateError(`Clipboard error: ${error.message}`);
+    }
+  });
+}
+
+async function loadSettings() {
+  try {
+    const data = await browserApi.storage.sync.get({ copyAllTabs: true, openInNewWindow: true });
+    state.copyAllTabs = data.copyAllTabs !== false;
+    state.openInNewWindow = data.openInNewWindow !== false;
+  } catch (error) {
+    console.error('Failed to load settings', error);
+    state.copyAllTabs = true;
+    state.openInNewWindow = true;
+  }
+
+  elements.allTabsToggle.checked = state.copyAllTabs;
+  elements.openInNewWindowToggle.checked = state.openInNewWindow;
+}
+
+function updateButtonLabels() {
+  elements.restoreButton.textContent = 'Restore Last Saved (new window)';
+  elements.clipboardButton.textContent = 'Open URLs from Clipboard (this window)';
+  const targetDescription = state.openInNewWindow ? 'new window' : 'current window';
+  elements.restoreButton.title = `Open saved URLs in a ${targetDescription}.`;
+  elements.clipboardButton.title = `Open clipboard URLs in a ${targetDescription}.`;
+}
+
+function handleRuntimeMessage(request) {
+  if (!request || typeof request !== 'object') {
+    return false;
+  }
+
+  switch (request.action) {
+    case 'updateStatus':
+      setMessage(request.message || '');
+      break;
+    case 'copyComplete':
+      handleCopyComplete(request);
+      break;
+    case 'copyError':
+      handleCopyError(request.message);
+      break;
+    case 'operationComplete':
+      handleOperationComplete(request);
+      break;
+    case 'operationError':
+      handleOperationError(request.message);
+      break;
+    default:
+      break;
+  }
+  return false;
+}
+
+function handleCopyComplete(payload) {
+  const text = payload && payload.text ? payload.text : '';
+  const stats = payload && payload.stats ? payload.stats : {};
+
+  navigator.clipboard.writeText(text).then(() => {
+    setMessage(`${stats.urlCount || 0} URL${stats.urlCount === 1 ? '' : 's'} copied to clipboard!`);
+    renderCopyStats(stats);
+    setBusyState(null);
+  }).catch((error) => {
+    handleCopyError(`Failed to write to clipboard: ${error.message}`);
+  });
+}
+
+function handleCopyError(message) {
+  setMessage(message || 'Failed to copy URLs.', true);
+  clearStats();
+  setBusyState(null);
+}
+
+function handleOperationComplete(payload) {
+  const stats = payload && payload.stats ? payload.stats : {};
+  setMessage(payload && payload.message ? payload.message : 'Operation completed.');
+  renderOperationStats(stats);
+  setBusyState(null);
+}
+
+function handleOperationError(message) {
+  setMessage(message || 'Operation failed.', true);
+  clearStats();
+  setBusyState(null);
+}
+
+function renderCopyStats(stats) {
+  const parts = [];
+  if (typeof stats.tabCount === 'number') {
+    parts.push(`<p>Tabs processed: ${stats.tabCount}</p>`);
+  }
+  if (typeof stats.urlCount === 'number') {
+    parts.push(`<p>URLs copied: ${stats.urlCount}</p>`);
+  }
+  if (typeof stats.characterCount === 'number') {
+    parts.push(`<p>Total characters: ${stats.characterCount}</p>`);
+  }
+  elements.stats.innerHTML = parts.join('');
+}
+
+function renderOperationStats(stats) {
+  const parts = [];
+  if (typeof stats.openedCount === 'number') {
+    parts.push(`<p>URLs opened: ${stats.openedCount}</p>`);
+  }
+  if (stats.source === 'lastSession' && stats.savedAt) {
+    try {
+      const savedDate = new Date(stats.savedAt);
+      parts.push(`<p>Last saved: ${savedDate.toLocaleString()}</p>`);
+    } catch (error) {
+      // ignore date parsing issues
+    }
+  }
+  if (parts.length === 0) {
+    clearStats();
+    return;
+  }
+  elements.stats.innerHTML = parts.join('');
+}
+
+function setBusyState(action) {
+  state.busyAction = action;
+
+  const busy = Boolean(action);
+  elements.copyButton.disabled = busy;
+  elements.restoreButton.disabled = busy;
+  elements.clipboardButton.disabled = busy;
+
+  if (action === 'copy') {
+    elements.copyButton.textContent = COPY_BUTTON_WORKING;
+  } else {
+    elements.copyButton.textContent = COPY_BUTTON_DEFAULT;
+  }
+}
+
+function setMessage(message, isError = false) {
+  elements.message.textContent = message || '';
+  if (isError) {
+    elements.message.classList.add('error');
+  } else {
+    elements.message.classList.remove('error');
+  }
+}
+
+function clearStats() {
+  elements.stats.textContent = '';
+}
+
+function handleImmediateError(message) {
+  setMessage(message, true);
+  clearStats();
+  setBusyState(null);
+}

--- a/vendor/browser-adapter.js
+++ b/vendor/browser-adapter.js
@@ -1,0 +1,95 @@
+(function initBrowserAdapter(global) {
+  if (!global) {
+    return;
+  }
+
+  if (typeof global.browser !== 'undefined' && global.browser) {
+    if (!global.browser.action && global.chrome && global.chrome.action) {
+      global.browser.action = global.chrome.action;
+    }
+    return;
+  }
+
+  const chromeApi = global.chrome;
+  if (!chromeApi) {
+    return;
+  }
+
+  const runtime = chromeApi.runtime;
+  const storage = chromeApi.storage;
+  const tabs = chromeApi.tabs;
+  const windows = chromeApi.windows;
+
+  const promisify = (fn, context) => {
+    return (...args) => {
+      return new Promise((resolve, reject) => {
+        let settled = false;
+        const callback = (result) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          if (runtime && runtime.lastError) {
+            reject(new Error(runtime.lastError.message));
+          } else {
+            resolve(result);
+          }
+        };
+
+        try {
+          fn.apply(context, [...args, callback]);
+        } catch (error) {
+          settled = true;
+          reject(error);
+        }
+      });
+    };
+  };
+
+  const browserShim = {
+    action: chromeApi.action,
+    runtime: {
+      getURL: runtime && runtime.getURL ? runtime.getURL.bind(runtime) : undefined,
+      onMessage: runtime ? runtime.onMessage : undefined,
+      sendMessage: runtime ? promisify(runtime.sendMessage, runtime) : undefined,
+      openOptionsPage: runtime && runtime.openOptionsPage ? promisify(runtime.openOptionsPage, runtime) : undefined
+    },
+    storage: {
+      sync: {},
+      local: {}
+    },
+    tabs: {},
+    windows: {}
+  };
+
+  if (storage && storage.sync) {
+    browserShim.storage.sync.get = promisify(storage.sync.get, storage.sync);
+    browserShim.storage.sync.set = promisify(storage.sync.set, storage.sync);
+    if (storage.sync.remove) {
+      browserShim.storage.sync.remove = promisify(storage.sync.remove, storage.sync);
+    }
+  }
+
+  if (storage && storage.local) {
+    browserShim.storage.local.get = promisify(storage.local.get, storage.local);
+    browserShim.storage.local.set = promisify(storage.local.set, storage.local);
+    if (storage.local.remove) {
+      browserShim.storage.local.remove = promisify(storage.local.remove, storage.local);
+    }
+  }
+
+  if (tabs) {
+    browserShim.tabs.query = promisify(tabs.query, tabs);
+    browserShim.tabs.create = promisify(tabs.create, tabs);
+    browserShim.tabs.update = promisify(tabs.update, tabs);
+  }
+
+  if (windows) {
+    browserShim.windows.create = promisify(windows.create, windows);
+    if (windows.getCurrent) {
+      browserShim.windows.getCurrent = promisify(windows.getCurrent, windows);
+    }
+  }
+
+  global.browser = browserShim;
+})(typeof globalThis !== 'undefined' ? globalThis : (typeof self !== 'undefined' ? self : this));


### PR DESCRIPTION
## Summary
- add a shared browser adapter and refactor the background worker to support copying, restoring, and clipboard imports across Firefox and Chromium
- refresh the popup with restore/open buttons, persistence for new-window preference, and improved status messaging
- update docs with the 1.50 release notes, QA checklist, and the implementation task roadmap

## Testing
- not run (extension manual testing required)


------
https://chatgpt.com/codex/tasks/task_b_68e56fbe6bec832184f09a1d4bb601ed