### PR TITLE
#P2-T1 Use shared adapter in background worker

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -5,7 +5,7 @@
 - [x] Update Manifest V3 metadata, permissions, and Firefox-specific settings (manifest validates in Chrome & Firefox). [#P1-T2]
 
 ## Phase 2 – Background capabilities
-- [ ] Refactor the background service worker to use the shared adapter and maintain existing copy/status flow (copy action mirrors current UX). [#P2-T1]
+- [x] Refactor the background service worker to use the shared adapter and maintain existing copy/status flow (copy action mirrors current UX). [#P2-T1]
 - [ ] Persist the last copied session in `storage.local` and implement restore helpers for current/new windows (restore reopens saved URLs). [#P2-T2]
 - [ ] Implement clipboard import handling with newline and JSON parsing plus internal URL filtering (invalid lines ignored gracefully). [#P2-T3]
 

--- a/background.js
+++ b/background.js
@@ -1,13 +1,17 @@
 importScripts('vendor/browser-adapter.js');
 
-if (typeof browser === 'undefined') {
+const browserApi = (typeof browserAdapter !== 'undefined' && browserAdapter && typeof browserAdapter.getBrowser === 'function')
+  ? browserAdapter.getBrowser()
+  : (typeof browser !== 'undefined' ? browser : undefined);
+
+if (!browserApi) {
   throw new Error('Browser adapter failed to initialize in background context.');
 }
 
-const runtime = browser.runtime;
-const storage = browser.storage;
-const tabsApi = browser.tabs;
-const windowsApi = browser.windows;
+const runtime = browserApi.runtime;
+const storage = browserApi.storage;
+const tabsApi = browserApi.tabs;
+const windowsApi = browserApi.windows;
 
 const INTERNAL_PROTOCOLS = new Set(['chrome:', 'chrome-extension:', 'moz-extension:', 'about:', 'edge:', 'view-source:']);
 

--- a/tests/test_background_adapter.py
+++ b/tests/test_background_adapter.py
@@ -1,0 +1,28 @@
+"""Regression tests for the background service worker bootstrap."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def load_file(relative_path: str) -> str:
+    """Return the text contents of *relative_path* from the repository root."""
+
+    project_root = Path(__file__).resolve().parent.parent
+    target_path = project_root / relative_path
+    return target_path.read_text(encoding="utf-8")
+
+
+def test_background_uses_shared_adapter() -> None:
+    """The background worker should pull the API from the shared adapter shim."""
+
+    background_source = load_file("background.js")
+    assert "browserAdapter.getBrowser()" in background_source
+
+
+def test_browser_adapter_exposes_getter() -> None:
+    """The adapter shim should expose a getter for shared usage."""
+
+    adapter_source = load_file("vendor/browser-adapter.js")
+    assert "browserAdapter" in adapter_source
+    assert "getBrowser" in adapter_source

--- a/vendor/browser-adapter.js
+++ b/vendor/browser-adapter.js
@@ -3,10 +3,29 @@
     return;
   }
 
+  const registerAdapter = (browserApi) => {
+    if (!browserApi) {
+      return;
+    }
+
+    const adapter = {
+      getBrowser() {
+        return browserApi;
+      }
+    };
+
+    if (typeof global.browserAdapter === 'undefined' || !global.browserAdapter) {
+      global.browserAdapter = adapter;
+    } else if (typeof global.browserAdapter.getBrowser !== 'function') {
+      global.browserAdapter.getBrowser = adapter.getBrowser;
+    }
+  };
+
   if (typeof global.browser !== 'undefined' && global.browser) {
     if (!global.browser.action && global.chrome && global.chrome.action) {
       global.browser.action = global.chrome.action;
     }
+    registerAdapter(global.browser);
     return;
   }
 
@@ -92,4 +111,5 @@
   }
 
   global.browser = browserShim;
+  registerAdapter(browserShim);
 })(typeof globalThis !== 'undefined' ? globalThis : (typeof self !== 'undefined' ? self : this));


### PR DESCRIPTION
## Summary
- route the background service worker through the shared browser adapter before touching extension APIs
- expose a reusable `browserAdapter.getBrowser` helper from the vendor shim
- add regression tests covering the adapter usage and mark task #P2-T1 complete

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

## Links
- Task: [TASKS.md#L8](TASKS.md#L8)

------
https://chatgpt.com/codex/tasks/task_b_68e5a87a013883219096cbe070406736