### PR TITLE
P2-T3: Implement clipboard import parsing filters

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -7,7 +7,7 @@
 ## Phase 2 – Background capabilities
 - [x] Refactor the background service worker to use the shared adapter and maintain existing copy/status flow (copy action mirrors current UX). [#P2-T1]
 - [x] Persist the last copied session in `storage.local` and implement restore helpers for current/new windows (restore reopens saved URLs). [#P2-T2]
-- [ ] Implement clipboard import handling with newline and JSON parsing plus internal URL filtering (invalid lines ignored gracefully). [#P2-T3]
+- [x] Implement clipboard import handling with newline and JSON parsing plus internal URL filtering (invalid lines ignored gracefully). [#P2-T3]
 
 ## Phase 3 – Popup experience
 - [ ] Redesign the popup UI with new buttons, open-in-new-window toggle, and status messaging (UI matches spec and remains accessible). [#P3-T1]

--- a/background.js
+++ b/background.js
@@ -215,10 +215,12 @@ function parseUrls(input) {
       const parsed = JSON.parse(trimmed);
       if (Array.isArray(parsed)) {
         rawList = parsed;
+      } else if (typeof parsed === 'string') {
+        rawList = splitLines(parsed);
       } else if (parsed && Array.isArray(parsed.urls)) {
         rawList = parsed.urls;
       } else if (parsed && typeof parsed.urls === 'string') {
-        rawList = [parsed.urls];
+        rawList = splitLines(parsed.urls);
       } else {
         rawList = splitLines(trimmed);
       }
@@ -226,7 +228,13 @@ function parseUrls(input) {
       rawList = splitLines(trimmed);
     }
   } else if (typeof input === 'object' && input.urls) {
-    rawList = Array.isArray(input.urls) ? input.urls : [input.urls];
+    if (Array.isArray(input.urls)) {
+      rawList = input.urls;
+    } else if (typeof input.urls === 'string') {
+      rawList = splitLines(input.urls);
+    } else {
+      rawList = splitLines(String(input.urls));
+    }
   }
 
   const validated = [];

--- a/tests/helpers/run_parse_urls.js
+++ b/tests/helpers/run_parse_urls.js
@@ -1,0 +1,51 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const projectRoot = path.resolve(__dirname, '..', '..');
+const backgroundSource = fs.readFileSync(path.join(projectRoot, 'background.js'), 'utf8');
+
+const stubApi = {
+  runtime: {
+    onMessage: { addListener: () => {} },
+    sendMessage: () => Promise.resolve(),
+  },
+  storage: {
+    local: {
+      get: () => Promise.resolve({}),
+      set: () => Promise.resolve(),
+    },
+  },
+  tabs: {
+    query: () => Promise.resolve([]),
+    create: () => Promise.resolve({}),
+    update: () => Promise.resolve({}),
+  },
+  windows: {
+    create: () => Promise.resolve({}),
+    getCurrent: () => Promise.resolve({ id: 1 }),
+  },
+};
+
+const context = {
+  console,
+  importScripts: () => {},
+  browserAdapter: { getBrowser: () => stubApi },
+  setTimeout,
+  clearTimeout,
+  URL,
+  Promise,
+  Error,
+};
+
+vm.createContext(context);
+vm.runInContext(backgroundSource, context, { filename: 'background.js' });
+
+const inputJson = process.env.INPUT_JSON;
+if (!inputJson) {
+  throw new Error('INPUT_JSON environment variable is required');
+}
+
+const inputValue = JSON.parse(inputJson);
+const result = context.parseUrls(inputValue);
+process.stdout.write(JSON.stringify(result));

--- a/tests/test_clipboard_import.py
+++ b/tests/test_clipboard_import.py
@@ -1,0 +1,64 @@
+"""Tests for clipboard parsing behaviour in the background worker."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any, Iterable
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+RUNNER_PATH = PROJECT_ROOT / "tests" / "helpers" / "run_parse_urls.js"
+
+
+def parse_urls(value: Any) -> list[str]:
+    """Invoke the background worker's ``parseUrls`` helper via Node.js."""
+
+    env = os.environ.copy()
+    env["INPUT_JSON"] = json.dumps(value)
+
+    result = subprocess.run(
+        ["node", str(RUNNER_PATH)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    output = result.stdout.strip()
+    return [] if not output else json.loads(output)
+
+
+def assert_urls(parsed: Iterable[str], expected: Iterable[str]) -> None:
+    assert list(parsed) == list(expected)
+
+
+def test_newline_separated_text_filters_internal_protocols() -> None:
+    parsed = parse_urls("https://example.com\nchrome://extensions\nhttps://openai.com")
+    assert_urls(parsed, ["https://example.com/", "https://openai.com/"])
+
+
+def test_json_array_input_filters_invalid_urls() -> None:
+    parsed = parse_urls([
+        "https://valid.test/one",
+        "not a url",
+        "about:blank",
+        "https://valid.test/two",
+    ])
+    assert_urls(parsed, ["https://valid.test/one", "https://valid.test/two"])
+
+
+def test_json_object_string_field_splits_lines() -> None:
+    parsed = parse_urls({"urls": "https://a.test\nhttps://b.test"})
+    assert_urls(parsed, ["https://a.test/", "https://b.test/"])
+
+
+def test_json_string_input_is_treated_as_multiline_text() -> None:
+    parsed = parse_urls("https://a.test\nhttps://b.test")
+    assert_urls(parsed, ["https://a.test/", "https://b.test/"])
+
+
+def test_serialised_json_string_is_split_into_multiple_urls() -> None:
+    parsed = parse_urls('"https://a.test\\nhttps://b.test"')
+    assert_urls(parsed, ["https://a.test/", "https://b.test/"])


### PR DESCRIPTION
## Summary
- enhance the background clipboard parser to split newline-delimited JSON strings and objects into discrete URLs
- add a Node-backed test harness and unit tests covering clipboard parsing and protocol filtering

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80

------
https://chatgpt.com/codex/tasks/task_b_68e5ad1b4d888321a6f4b667ef147587