### PR TITLE
#P5-T2 Record 1.50 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Added session restore and clipboard import actions with URL validation.
 - Refreshed the popup UI with new controls and status messaging.
 - Updated documentation and permissions, keeping the extension offline-only.
+- Confirmed the manifest version bump to 1.50 across Chrome- and Firefox-targeted builds.

--- a/TASKS.md
+++ b/TASKS.md
@@ -19,4 +19,4 @@
 
 ## Phase 5 – Documentation & release
 - [x] Update README with multi-browser setup, feature overview, and QA checklist (docs reflect new workflow). [#P5-T1]
-- [ ] Record the 1.50 release in CHANGELOG and confirm version bump (changelog and manifest show 1.50). [#P5-T2]
+- [x] Record the 1.50 release in CHANGELOG and confirm version bump (changelog and manifest show 1.50). [#P5-T2]

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -1,0 +1,33 @@
+"""Regression tests ensuring release metadata stays in sync."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+def test_changelog_mentions_current_manifest_version() -> None:
+    """The changelog must include an entry for the published manifest version."""
+
+    repo_root = Path(__file__).resolve().parent.parent
+    manifest_path = repo_root / "manifest.json"
+    changelog_path = repo_root / "CHANGELOG.md"
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest_version = manifest["version"]
+
+    changelog_text = changelog_path.read_text(encoding="utf-8")
+    heading_pattern = re.compile(
+        rf"^##\s+{re.escape(manifest_version)}\s+-\s+\d{{4}}-\d{{2}}-\d{{2}}$",
+        re.MULTILINE,
+    )
+
+    match = heading_pattern.search(changelog_text)
+    assert match is not None, "Changelog must contain a heading for the current manifest version."
+
+    body_start = match.end()
+    next_heading_index = changelog_text.find("\n## ", body_start)
+    body_text = changelog_text[body_start:next_heading_index if next_heading_index != -1 else None]
+
+    assert re.search(r"^- ", body_text, re.MULTILINE), "Release entry must include bullet highlights."


### PR DESCRIPTION
## Summary
- Extend the 1.50 changelog entry with an explicit confirmation of the manifest version bump.
- Add a regression test that ensures the changelog contains a dated entry for the current manifest version with release highlights.
- Mark task #P5-T2 complete in TASKS.md now that the 1.50 release is documented.

## Testing
- pip install -e .
- ruff check .
- pytest -q --cov=src --cov-fail-under=80


------
https://chatgpt.com/codex/tasks/task_b_68e5c7e29c68832192e78d715f9cb23e